### PR TITLE
chore(deps-dev): remove commitizen

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,12 +18,7 @@ In this project, merge commits are not permitted, and contributors should be fam
 
 ### ✍️ Conventional Commits
 
-This project uses [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/), ensuring a standardized format for describing changes. This consistency enhances collaboration, code review, and automated release processes, ultimately improving project maintainability and code quality. Commit messages are checked with [gitlint](https://github.com/jorisroovers/gitlint) as part of the CI pipeline. If you need help composing your messages, you may use the [commitizen]() CLI, which is bundled with the dev dependencies:
-
-```shell
-git add .
-hatch run dev:cz commit
-```
+This project uses [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/), ensuring a standardized format for describing changes. This consistency enhances collaboration, code review, and automated release processes, ultimately improving project maintainability and code quality. Commit messages are checked with [gitlint](https://github.com/jorisroovers/gitlint) as part of the CI pipeline. If you need help composing your messages, you may consider using the [commitizen](https://commitizen-tools.github.io/commitizen/) CLI or a similar tool.
 
 ### 📄 Code Style, Linting, Types
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
   "pytest",
   "ruff",
   "mypy>=1.0.0",
-  "commitizen",
   "gitlint",
   "uvicorn",
   "httpx",

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -5,7 +5,6 @@
 # - pytest
 # - ruff
 # - mypy>=1.0.0
-# - commitizen
 # - gitlint
 # - uvicorn
 # - httpx
@@ -22,29 +21,19 @@ anyio==4.4.0
     #   httpx
     #   starlette
     #   watchfiles
-argcomplete==3.3.0
-    # via commitizen
 arrow==1.2.3
     # via gitlint-core
 certifi==2024.7.4
     # via
     #   httpcore
     #   httpx
-charset-normalizer==3.3.2
-    # via commitizen
 click==8.1.3
     # via
     #   gitlint-core
     #   typer
     #   uvicorn
-colorama==0.4.6
-    # via commitizen
-commitizen==3.27.0
-    # via hatch.envs.dev
 coverage==7.5.4
     # via hatch.envs.dev
-decli==0.6.2
-    # via commitizen
 dnspython==2.6.1
     # via email-validator
 email-validator==2.2.0
@@ -78,14 +67,10 @@ idna==3.7
     #   anyio
     #   email-validator
     #   httpx
-importlib-metadata==7.2.1
-    # via commitizen
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.4
-    # via
-    #   commitizen
-    #   fastapi
+    # via fastapi
 mangum==0.17.0
     # via hatch.envs.dev
 markdown-it-py==3.0.0
@@ -101,13 +86,9 @@ mypy-extensions==1.0.0
 orjson==3.10.6
     # via fastapi
 packaging==24.1
-    # via
-    #   commitizen
-    #   pytest
+    # via pytest
 pluggy==1.5.0
     # via pytest
-prompt-toolkit==3.0.36
-    # via questionary
 pydantic==2.8.2
     # via
     #   hatch.envs.dev
@@ -130,11 +111,7 @@ python-dotenv==1.0.1
 python-multipart==0.0.9
     # via fastapi
 pyyaml==6.0.1
-    # via
-    #   commitizen
-    #   uvicorn
-questionary==2.0.1
-    # via commitizen
+    # via uvicorn
 rich==13.7.1
     # via typer
 ruff==0.5.1
@@ -151,15 +128,11 @@ sniffio==1.3.1
     #   httpx
 starlette==0.37.2
     # via fastapi
-termcolor==2.4.0
-    # via commitizen
 tomli==2.0.1
     # via
     #   coverage
     #   mypy
     #   pytest
-tomlkit==0.12.5
-    # via commitizen
 typer==0.12.3
     # via fastapi-cli
 typing-extensions==4.12.2
@@ -182,9 +155,5 @@ uvloop==0.19.0
     # via uvicorn
 watchfiles==0.22.0
     # via uvicorn
-wcwidth==0.2.13
-    # via prompt-toolkit
 websockets==12.0
     # via uvicorn
-zipp==3.19.2
-    # via importlib-metadata


### PR DESCRIPTION
### 🙋‍♀️ Why is the change important?

Developers may use their own choice of tools to write the commit messages, there is not a real need to have commitizen installed. It's also creating all kinds of problems for dependabot.

### 📜 What does this PR change?

Remove commitizen CLI from dev deps.

### 🙅‍♂️ Limitations

None

### 🚨 Issues

None

### 💁 Additional information

None

### ✅ Checklist

<!-- Check all applicable fields or delete them if they aren't relevant. -->

- [x] **I have read and understood the [contributing guidelines](/CONTRIBUTING.md) guidelines.**
- [x] **The title of the pull request follows the pattern explained in the [branching paragraph](/CONTRIBUTING.md#🌳-branches).**
- [x] **I have cleaned up my commits and they follow the [conventional commits](/CONTRIBUTING.md#✍️-conventional-commits) convention.**
- [x] **All additions and/or changes to function code are covered by tests.**
- [x] **The documentation has been updated where necessary.**
